### PR TITLE
11 reusability changes

### DIFF
--- a/wagtail_content_import/mappers/base.py
+++ b/wagtail_content_import/mappers/base.py
@@ -1,6 +1,6 @@
 class BaseMapper:
     """
-    Base mapper to take a parser output (sintermediate_stream) and map it to the desired input format on self.map()
+    Base mapper to take a parser output (intermediate_stream) and map it to the desired input format on self.map()
     """
 def map(self, intermediate_stream):
         raise NotImplementedError

--- a/wagtail_content_import/mappers/base.py
+++ b/wagtail_content_import/mappers/base.py
@@ -1,9 +1,6 @@
 class BaseMapper:
     """
-    Base mapper to take a parser output (self.intermediate_stream) and map it to the desired input format on self.map()
+    Base mapper to take a parser output (sintermediate_stream) and map it to the desired input format on self.map()
     """
-    def __init__(self, intermediate_stream):
-        self.intermediate_stream = intermediate_stream
-
-    def map(self):
+def map(self, intermediate_stream):
         raise NotImplementedError

--- a/wagtail_content_import/mappers/streamfield.py
+++ b/wagtail_content_import/mappers/streamfield.py
@@ -7,9 +7,9 @@ class StreamFieldMapper(BaseMapper):
     dictionaries to a StreamField-compatible list: typically (block_type_str, block_contents) tuples.
     """
 
-    def map(self):
+    def map(self, intermediate_stream):
         output_streamfield = []
-        for element in self.intermediate_stream:
+        for element in intermediate_stream:
             conversion_method = getattr(self, element['type'], None)
             if conversion_method:
                 converted_element = conversion_method(element)

--- a/wagtail_content_import/mappers/streamfield.py
+++ b/wagtail_content_import/mappers/streamfield.py
@@ -1,5 +1,5 @@
 from .base import BaseMapper
-from .utils import to_tuple
+from .utils import to_tuple, image_element_to_tuple
 
 
 class StreamFieldMapper(BaseMapper):
@@ -13,6 +13,7 @@ class StreamFieldMapper(BaseMapper):
     """
 
     type_to_conversion_function_dict = {
+        'image': image_element_to_tuple
     }
 
     def map(self):

--- a/wagtail_content_import/mappers/streamfield.py
+++ b/wagtail_content_import/mappers/streamfield.py
@@ -1,26 +1,17 @@
 from .base import BaseMapper
-from .utils import to_tuple, image_element_to_tuple
 
 
 class StreamFieldMapper(BaseMapper):
     """
     On self.map(), converts a parsed document (self.intermediate_stream) composed of a list of {'type': str, 'value': value} element
-    dictionaries to a StreamField-compatible list of (block_type_str, block_contents) tuples. By default, the
-    block_type_str is set to element['type'] and block_contents to element[value].
-
-    This can be customised by subclassing and populating type_to_conversion_function_dict, where the keys should be element['type'] strings,
-    and the values should be functions, taking an element and returning a StreamField-compatible tuple.
+    dictionaries to a StreamField-compatible list: typically (block_type_str, block_contents) tuples.
     """
-
-    type_to_conversion_function_dict = {
-        'image': image_element_to_tuple
-    }
 
     def map(self):
         output_streamfield = []
         for element in self.intermediate_stream:
-            conversion_function = self.type_to_conversion_function_dict.get(element["type"], to_tuple)
-            converted_element = conversion_function(element)
-            output_streamfield.append(converted_element)
+            conversion_method = getattr(self, element['type'], None)
+            if conversion_method:
+                converted_element = conversion_method(element)
+                output_streamfield.append(converted_element)
         return output_streamfield
-

--- a/wagtail_content_import/mappers/utils.py
+++ b/wagtail_content_import/mappers/utils.py
@@ -1,6 +1,33 @@
+import requests
+from django.core.files.base import ContentFile
+from wagtail.images import get_image_model
+
+
 def to_tuple(element, new_type=None):
     """
     Converts a parser output element {'type': type, 'value': value} into (type, value), changing type to new_type if supplied.
     """
     type = new_type if new_type else element['type']
     return (type, element['value'])
+
+
+def image_element_to_tuple(element):
+    url = element['value']
+    image = import_image_from_url(url)
+    return ('image', image)
+
+
+def import_image_from_url(url):
+    response = requests.get(url)
+
+    if not response.status_code == 200:
+        return
+
+    file_name = url.split("/")[-1]
+
+    Image = get_image_model()
+    image = Image(title=file_name)
+    image.file.save(file_name, ContentFile(response.content))
+    image.save()
+
+    return image

--- a/wagtail_content_import/models.py
+++ b/wagtail_content_import/models.py
@@ -17,8 +17,8 @@ class ContentImportMixin:
         """
         title = parsed_doc['title']
         mapper_class = cls.mapper_class
-        mapper = mapper_class(parsed_doc['elements'])
-        imported_data = mapper.map()
+        mapper = mapper_class()
+        imported_data = mapper.map(parsed_doc['elements'])
         return cls(
             title=title,
             slug=slugify(title),


### PR DESCRIPTION
Restructures BaseMapper:

- No longer takes parser output in constructor, but in map method

Restructures StreamFieldMapper map method:

- Gets methods corresponding to element, rather than using type to conversion function dictionary