### PR TITLE
Pages docs

### DIFF
--- a/docs/basic_usage.md
+++ b/docs/basic_usage.md
@@ -1,0 +1,39 @@
+# Basic Usage
+
+1. To enable import for a Page model, it should inherit from `ContentImportMixin` 
+(`wagtail_content_import.models.ContentImportMixin`). By default, content will be imported into into a StreamField called body
+(see [Changing Import Fields](changing_import_fields.md) for how to change this).
+
+2. You'll then need to create a Mapper, which maps the parsed document into your StreamField blocks. Create a class deriving from `wagtail_content_import.mappers.streamfield.StreamFieldMapper`:
+
+        from wagtail_content_import.mappers.converters import ImageConverter, RichTextConverter, TableConverter, TextConverter 
+        from wagtail_content_import.mappers.streamfield import StreamFieldMapper
+        
+        class MyMapper(StreamFieldMapper):
+            html = RichTextConverter('my_heading_block')
+            image = ImageConverter('my_image_block')
+            heading = TextConverter('my_heading_block')
+            table = TableConverter('my_table_block')    
+   
+      This would map to an example StreamField defined as:
+   
+        from wagtail.images.blocks import ImageChooserBlock
+        from wagtail.core.blocks import CharBlock, RichTextBlock, StreamBlock
+        from wagtail.contrib.table_block.blocks import TableBlock
+        
+        class BaseStreamBlock(StreamBlock):
+        """
+        Define the custom blocks that `StreamField` will utilize
+        """
+            my_heading_block = CharBlock()
+            my_paragraph_block = RichTextBlock()
+            my_image_block = ImageChooserBlock()
+            my_table_block = TableBlock()
+    
+      Note that the converters require the fields rather than the block classes: `'my_heading_block'`, not `CharBlock`.
+
+      The above example assumes use of the simple blocks included with Wagtail. For StructBlocks, see [Working with StructBlocks](structblocks.md).
+
+3. Set `mapper_class` on your Page model to your new mapper class (or set `WAGTAILCONTENTIMPORT_DEFAULT_MAPPER` to your mapper use it for all imports by default).
+
+4. You should now see a button near the action menu when creating a new Page of your class in the admin, giving you the option to import a document.

--- a/docs/basic_usage.md
+++ b/docs/basic_usage.md
@@ -1,7 +1,7 @@
 # Basic Usage
 
 1. To enable import for a Page model, it should inherit from `ContentImportMixin` 
-(`wagtail_content_import.models.ContentImportMixin`). By default, content will be imported into into a StreamField called body
+(`wagtail_content_import.models.ContentImportMixin`). By default, content will be imported into into a StreamField called `body`
 (see [Changing Import Fields](changing_import_fields.md) for how to change this).
 
 2. You'll then need to create a Mapper, which maps the parsed document into your StreamField blocks. Create a class deriving from `wagtail_content_import.mappers.streamfield.StreamFieldMapper`:
@@ -22,9 +22,9 @@
         from wagtail.contrib.table_block.blocks import TableBlock
         
         class BaseStreamBlock(StreamBlock):
-        """
-        Define the custom blocks that `StreamField` will utilize
-        """
+            """
+            Define the custom blocks that `StreamField` will utilize
+            """
             my_heading_block = CharBlock()
             my_paragraph_block = RichTextBlock()
             my_image_block = ImageChooserBlock()

--- a/docs/changing_import_fields.md
+++ b/docs/changing_import_fields.md
@@ -1,0 +1,23 @@
+To change how the document's data is imported to the Page model - for example, importing to a StreamField other than `body`,
+you'll need to override the `create_from_import` method. On the `ContentImportMixin`, this is defined as:
+```python
+    from django.utils.text import slugify
+
+    @classmethod
+    def create_from_import(cls, parsed_doc, user):
+        """
+        Factory method to create the Page and populate it from a parsed document.
+        """
+        title = parsed_doc['title']
+        mapper_class = cls.mapper_class
+        mapper = mapper_class()
+        imported_data = mapper.map(parsed_doc['elements'], user=user)
+        return cls(
+            title=title,
+            slug=slugify(title),
+            body=imported_data,
+            owner=user,
+        )
+```
+
+So to import into a different field, simply replace `body` with the name of your custom field.

--- a/docs/custom_converters.md
+++ b/docs/custom_converters.md
@@ -1,0 +1,22 @@
+Converters are callable classes which convert `{type: type, 'value': value}` elements 
+in a parsed document to StreamField blocks. You can write your own custom converters to include
+functionality not in the core app: for example, [working with StructBlocks](structblocks.md).
+
+Converters should inherit from `wagtail_content_import.mappers.converters.BaseConverter`, which
+provides an `__init__` method which populates `self.block_name`, the field name of the StreamField
+block the converter is creating.
+ 
+Converters should implement a `__call__(self, element, **kwargs)` method which returns a 
+StreamField-compatible tuple of `(self.block_name, content)` for an `element` of the form `{type: type, 'value': value}`
+
+For example, the default TextConverter is implemented simply as:
+
+```python
+from wagtail_content_import.parsers.converters import BaseConverter
+
+class TextConverter(BaseConverter):
+    def __call__(self, element, **kwargs):
+        return (self.block_name, element['value'])
+```
+
+To see how to use a custom converter to map into a StructBlock, see [working with StructBlocks](structblocks.md).

--- a/docs/flow.md
+++ b/docs/flow.md
@@ -1,0 +1,27 @@
+## The Content Import Flow
+
+The Wagtail Content Import app provides:
+
+- **Pickers** - which select and import raw document data 
+- **Parsers** - which parse the raw document data into a standard intermediate form
+- **Mappers** - which convert this intermediate form into a final output (typically a Wagtail StreamField)
+
+The typical flow is as follows, for a `Page` model with `ContentImportMixin`:
+
+1. The `Create` view in the Wagtail Admin provides a button, which calls a picker.
+
+2. The picker enables a document to be selected, and makes a POST request to the `Create` view with the document data.
+
+3. The Wagtail hook for `"before_create_page"` in the picker detects the document, and calls a relevant parser.
+
+4. The parser's `parse()` method converts the raw document data to a list of `{'type': type, 'value': value}` elements.
+
+5. The `create_page_from_import` function is called, which in turn passes the parsed data to the Page model's 
+`create_from_import` method (inherited from `ContentImportMixin`).
+
+6. By default, this creates an instance of the Page's `mapper_class`, then uses its `map()` method to call a relevant
+Converter for each `{'type': type, 'value': value}` element. This returns a StreamField-compatible list of  `('block_name', block_content)` tuples.
+
+7. Finally a `Page` model instance is created (but not saved) with the document's title, and the content inserted into a field called `body`. 
+
+8. The `Create` view is then rendered with the `Page` model instance bound to the form.

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -1,7 +1,6 @@
 ## Requirements:
 * Django 2.2
 * Wagtail 2.2
-* Python 3
 
 ### To set up:
  1. Run `python3 pip install wagtail-content-import`.

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -1,0 +1,24 @@
+## Requirements:
+* Django 2.2
+* Wagtail 2.2
+* Python 3
+
+### To set up:
+ 1. Run `python3 pip install wagtail-content-import`.
+ 2. Add `'wagtail_content_import'` to `INSTALLED_APPS` above `wagtail.admin`
+ 3. Add the urls: include `wagtail_import.urls` in your `urlpatterns` in `urls.py`. This could look like:
+    
+        from django.conf.urls import include, url
+        from wagtail_content_import import urls as wagtail_content_import_urls
+        urlpatterns += [
+            url(r'', include(wagtail_content_import_urls)),
+            ]
+    Note that `wagtail_content_import.urls` must be above `wagtail.core.urls` in your `urlpatterns`.
+    
+ 3. Add the relevant pickers:
+     - To import from Google Docs, add`'wagtail_content_import.pickers.google'` to `INSTALLED_APPS` above `wagtail.admin`,
+  then follow the steps given in [Google Docs Setup](google_docs_setup.md)
+     - To import from OneDrive/SharePoint, add`'wagtail_content_import.pickers.microsoft'` to `INSTALLED_APPS` above `wagtail.admin`,
+  then follow the steps given in [Microsoft Setup](microsoft_setup.md)
+  
+ 4. You're now ready to set up how content will be imported to your Page models: see [Basic Usage](basic_usage.md)

--- a/docs/google_docs_setup.md
+++ b/docs/google_docs_setup.md
@@ -1,0 +1,33 @@
+# Setting Up Google Integration
+
+Wagtail Google Docs integration relies on Google APIs, which you will first need to enable for your project:
+
+1. Navigate to the [Google API Library](https://console.developers.google.com/apis/library). Select a project for your Wagtail site, or create a new one now.
+
+2. Find and enable the [Google Docs](https://console.developers.google.com/apis/library/docs.googleapis.com) and [Google Drive](https://console.developers.google.com/apis/library/drive.googleapis.com) APIs.
+    
+3. Find and enable the [Google Picker](https://console.developers.google.com/apis/api/picker.googleapis.com) API, and copy its API key to the setting `GOOGLE_PICKER_API_KEY`.
+
+4. Open the [Credentials](https://console.developers.google.com/apis/credentials) page in the API Console.
+
+5. Select `Create credentials`, then `OAuth client ID`
+
+6. If you haven't already configured the consent screen, you will need to configure this now.
+
+    1. Under `Scopes for Google APIs`, click `Add scope`.
+
+    2. Add `../auth/documents.readonly` and `../auth/drive.readonly` scopes.
+
+        Note: adding these sensitive scopes means that you will need to submit your project for verification by Google to
+        avoid user caps and warning pages during use.
+        
+    3. Add your domain to `Authorised domains`.
+
+ 7. For `Application type`, choose `Web application`
+
+ 8. Under `Authorised JavaScript origins`, add your domain.
+
+ 9. On the Credentials page, next to your Client ID, click the download item to download a JSON file of your client
+    secret.
+
+ 10. Copy the text from this file, and use it to set `GOOGLE_OAUTH_CLIENT_CONFIG`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,17 @@
+# Welcome to MkDocs
+
+For full documentation visit [mkdocs.org](https://mkdocs.org).
+
+## Commands
+
+* `mkdocs new [dir-name]` - Create a new project.
+* `mkdocs serve` - Start the live-reloading docs server.
+* `mkdocs build` - Build the documentation site.
+* `mkdocs help` - Print this help message.
+
+## Project layout
+
+    mkdocs.yml    # The configuration file.
+    docs/
+        index.md  # The documentation homepage.
+        ...       # Other markdown pages, images and other files.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,17 +1,19 @@
-# Welcome to MkDocs
+# Welcome to Wagtail Content Import's Documentation
 
-For full documentation visit [mkdocs.org](https://mkdocs.org).
+Wagtail Content Import is a module for Wagtail that provides functionality for importing page content from 
+third-party sources. Page content is imported into a StreamField, using a set of customisable mappings.
+Currently supports:
 
-## Commands
+###As sources:
+- Google Docs:
+- OneDrive/SharePoint
 
-* `mkdocs new [dir-name]` - Create a new project.
-* `mkdocs serve` - Start the live-reloading docs server.
-* `mkdocs build` - Build the documentation site.
-* `mkdocs help` - Print this help message.
-
-## Project layout
-
-    mkdocs.yml    # The configuration file.
-    docs/
-        index.md  # The documentation homepage.
-        ...       # Other markdown pages, images and other files.
+###As files:
+- Google Docs documents with:
+    - Rich text
+    - Tables
+    - Images
+    - Headings
+- Docx files with:
+    - Text with bold and italics
+    - Headings

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,14 +1,14 @@
 # Welcome to Wagtail Content Import's Documentation
 
-Wagtail Content Import is a module for Wagtail that provides functionality for importing page content from 
-third-party sources. Page content is imported into a StreamField, using a set of customisable mappings.
+Wagtail Content Import is a module for importing page content into Wagtail from third-party sources. 
+Page content is imported into a StreamField, using a set of customisable mappings.
 Currently supports:
 
-###As sources:
+### As sources:
 - Google Docs:
 - OneDrive/SharePoint
 
-###As files:
+### As files:
 - Google Docs documents with:
     - Rich text
     - Tables
@@ -17,3 +17,5 @@ Currently supports:
 - Docx files with:
     - Text with bold and italics
     - Headings
+
+"for importing page content into Wagtail from third-party sources"

--- a/docs/microsoft_setup.md
+++ b/docs/microsoft_setup.md
@@ -1,0 +1,22 @@
+# Setting Up OneDrive/SharePoint Integration
+
+Wagtail OneDrive/SharePoint integration relies on Microsoft APIs, which you will first need to enable for your project:
+
+1. Navigate to the [Microsoft Azure app registrations page](https://portal.azure.com/#blade/Microsoft_AAD_RegisteredApps/ApplicationsListBlade)
+
+2. If you don't have a registration for your project, create a new registration now.
+
+3. Either while creating your registration, or by selecting your project and navigating to `Authentication`, add a new `redirect URI`:
+
+    If you have included `wagtail_content_import.urls` as follows:
+    
+    ```python
+      url(r'ADDITIONAL_URL_PATH/', include(wagtail_content_import_urls))
+    ```
+   
+   The redirect URI will be: `https://BASE_URL/ADDITIONAL_URL_PATH/microsoft/auth/`
+   (substituting BASE_URL for your site's url, and ADDITIONAL_URL_PATH for the path under which you have included `wagtail_content_import.urls`)
+
+4. Navigate to `Authentication`. Under `Implicit grant`, add `Access tokens`, and save.
+
+5. Finally, navigate to `Overview`, and copy the `Application (client) ID` into the `MICROSOFT_CLIENT_ID` setting.

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -1,4 +1,4 @@
-##General Settings
+## General Settings
 
 #### `WAGTAILCONTENTIMPORT_DEFAULT_MAPPER`:
 
@@ -13,7 +13,7 @@ The DocumentParser class used for Google Docs. Defaults to `GoogleDocumentParser
 
 The DocumentParser class used for .docx files. Defaults to `DocxParser`.
 
-##Google Picker Settings
+## Google Picker Settings
 
 #### `GOOGLE_OAUTH_CLIENT_CONFIG` (Required):  
 
@@ -23,7 +23,7 @@ The app's Google client secret. (See: [Google Docs Setup](google_docs_setup.md))
 
 The app's Google Picker API key, allowing selection of Google Docs. (See: [Google Docs Setup](google_docs_setup.md))
 
-##Microsoft Picker Settings
+## Microsoft Picker Settings
 
 #### `MICROSOFT_CLIENT_ID` (Required):  
 

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -1,0 +1,30 @@
+##General Settings
+
+#### `WAGTAILCONTENTIMPORT_DEFAULT_MAPPER`:
+
+The Mapper class used by default for Page models with ContentImportMixin, unless mapper_class is overridden.
+Defaults to StreamFieldMapper.
+
+#### `WAGTAILCONTENTIMPORT_GOOGLE_PARSER`:
+
+The DocumentParser class used for Google Docs. Defaults to `GoogleDocumentParser`.
+
+#### `WAGTAILCONTENTIMPORT_GOOGLE_PARSER`:
+
+The DocumentParser class used for .docx files. Defaults to `DocxParser`.
+
+##Google Picker Settings
+
+#### `GOOGLE_OAUTH_CLIENT_CONFIG` (Required):  
+
+The app's Google client secret. (See: [Google Docs Setup](google_docs_setup.md))
+
+#### `GOOGLE_PICKER_API_KEY` (Required):
+
+The app's Google Picker API key, allowing selection of Google Docs. (See: [Google Docs Setup](google_docs_setup.md))
+
+##Microsoft Picker Settings
+
+#### `MICROSOFT_CLIENT_ID` (Required):  
+
+The app's Microsoft Azure client ID. (See: [Microsoft Setup](microsoft_setup.md))

--- a/docs/structblocks.md
+++ b/docs/structblocks.md
@@ -41,7 +41,7 @@ class HeadingBlockConverter(BaseConverter):
         return (self.block_name, {'heading_text': element['value'], 'size': 'h2'})
 ```
 
-##A More Complex Example: A Custom ImageBlock
+# #A More Complex Example: A Custom ImageBlock
 
 For a custom ImageBlock:
 

--- a/docs/structblocks.md
+++ b/docs/structblocks.md
@@ -1,0 +1,86 @@
+To convert elements in the parsed document to a StructBlock, you'll need to write a custom converter (see [Writing Custom Converters](custom_converters.md).)
+
+For a StructBlock, the converter output of a `(self.block_name, content)` tuple should provide `content` as a dict. For example, for a StructBlock:
+
+```python
+from wagtail.core.blocks import CharBlock, ChoiceBlock, StructBlock
+
+class HeadingBlock(StructBlock):
+    """
+    Custom `StructBlock` that allows the user to select h2 - h4 sizes for headers
+    """
+    heading_text = CharBlock(classname="title", required=True)
+    size = ChoiceBlock(choices=[
+        ('', 'Select a header size'),
+        ('h2', 'H2'),
+        ('h3', 'H3'),
+        ('h4', 'H4')
+    ], blank=True, required=False)
+
+    class Meta:
+        icon = "title"
+        template = "blocks/heading_block.html"
+```
+
+`content` should be:
+
+```python
+{
+    'heading_text': heading_text,
+    'size': size,
+}
+```
+
+To do this, we could write a converter:
+
+```python
+from wagtail_content_import.mappers.converters import BaseConverter
+
+class HeadingBlockConverter(BaseConverter):
+    def __call__(self, element, **kwargs):
+        return (self.block_name, {'heading_text': element['value'], 'size': 'h2'})
+```
+
+##A More Complex Example: A Custom ImageBlock
+
+For a custom ImageBlock:
+
+```python
+from django.utils.safestring import mark_safe
+from wagtail.core.blocks import BooleanBlock, StructBlock
+from wagtail.images.blocks import ImageChooserBlock
+
+
+class ImageBlock(StructBlock):
+
+    show_full_image = BooleanBlock(required=False)
+    image = ImageChooserBlock()
+
+    class Meta:
+        icon = "image / picture"
+        admin_text = mark_safe("<b>Image Block</b>")
+        label = "Image Block"
+        template = "pages/blocks/image_block.html" 
+```
+
+In a StreamField:
+
+```python
+from wagtail.core.blocks import StreamBlock
+
+class BaseBodyStreamBlock(StreamBlock):
+    image_block = ImageBlock()
+```
+
+We can write a custom converter which borrows some of the functionality of `ImageConverter`:
+
+```python
+from wagtail_content_import.mappers.converters import BaseConverter, ImageConverter
+
+class ImageBlockConverter(BaseConverter):
+    def __call__(self, element, user, *args, **kwargs):
+        image_url = element['value']
+        image_name, image_content = ImageConverter.fetch_image(image_url)
+        image = ImageConverter.import_as_image_model(image_name, image_content, owner=user)
+        return (self.block_name, {'show_full_image': None, 'image': image})
+```

--- a/docs/submitting_backend.md
+++ b/docs/submitting_backend.md
@@ -1,0 +1,205 @@
+Thanks for being interested in contributing! All contributions should be submitted as pull requests
+to the [Wagtail Content Import repository](https://github.com/torchbox/wagtail-content-import).
+
+
+## Submitting a New Picker
+
+If you're planning on submitting a new picker - apps which enable choosing and importing a file from a 
+remote source - you'll need to follow this blueprint:
+
+###Overview and File Structure
+
+Inside `wagtail_content_import.pickers`, your app should have the following structure:
+
+- `my_picker`
+    - `static`
+        - `wagtail_content_import`
+            - `MY_PICKER.js`
+    - `templates`
+        - `wagtail_content_import`
+            - `MY_PICKER_js_init.html`
+    - `__init__.py`
+    - `apps.py`
+    - `utils.py`
+    - `wagtail_hooks.py`
+
+Where `MY_PICKER` should be replaced with the name of your picker.
+
+- `MY_PICKER.js` provides the JavaScript class for your picker, which will select a file and make
+a POST request to the page with relevant data using a hidden form
+- `MY_PICKER_js_init.html` creates an instance of that class on the `Create` page, using
+  a template filled in with the relevant settings,
+  and sets up a listener to call that class's `.show()` method on clicking the relevant import
+  button.
+- `__init__.py` and `apps.py` set your app's name and label.
+- `utils.py` adds your Python picker class, eg `GooglePicker`
+- `wagtail_hooks.py` registers your picker using a Wagtail hook, and adds a `before_create_page` hook
+to actually take the POST-ed document data and import it, using a parser.
+
+The following examples will follow a picker which needs a variable `AUTH_PARAMETERS` available in the 
+JavaScript in order to import content.
+
+####`MY_PICKER.js`
+
+This adds the JavaScript class for your picker, and adds it to the window. It should implement
+a method to show the picker, and upon choosing, make a POST request to the page using a hidden form
+with relevant data that allows Wagtail to import the document: for the Google picker, this is a JSON
+containing the document; for the Microsoft picker, this is a temporary url allowing the file to be downloaded.
+
+Eg:
+
+```javascript
+(function() {
+    class MyPicker {
+        constructor(AUTH_PARAMETERS, createPageUrl, csrfToken) {
+        this.AUTH_PARAMETERS = AUTH_PARAMETERS;
+        this.createPageUrl = createPageUrl;
+        this.csrfToken = csrfToken;
+        }
+
+        post_data(response) {
+            // POST relevant data to the page
+            // Use a hidden form so the browser reloads with the result of this request
+            let form = document.createElement('form');
+            form.action = this.createPageUrl;
+            form.method = 'POST';
+            form.style.visibility = 'hidden';
+            document.body.appendChild(form);
+
+            let csrfTokenField = document.createElement('input');
+            csrfTokenField.type = 'hidden';
+            csrfTokenField.name = 'csrfmiddlewaretoken';
+            csrfTokenField.value = this.csrfToken;
+            form.appendChild(csrfTokenField);
+
+            let myDocField = document.createElement('input');
+            myDocField.type = 'hidden';
+            myDocField.name = 'my-doc';
+            myDocField.value = response.value;
+            form.appendChild(myDocField);
+
+            form.submit();
+        }
+
+
+        show() {
+          # Open the picker here, and call this.post_data(response) on successfully getting a file
+        }
+    }
+
+    window.MyPicker = MyPicker;
+})();
+```
+
+####`MY_PICKER_js_init.html`
+
+This should provide a Django template which creates an instance of your JS picker class, populated with
+the relevant variables, which can be filled in by the Django side using your Python picker class. It must also add a listener to the 
+relevant import button, such that when it is clicked, it calls `myPicker.show()`.
+
+Eg:
+
+```html
+<script type="text/javascript">
+    document.addEventListener('DOMContentLoaded', function() {
+        document.querySelectorAll('[data-content-import-picker="my_picker"]').forEach(function (element) {
+            let myPicker = new MyPicker({{ AUTH_PARAMETERS }}, element.dataset.createPageUrl, '{{ csrf_token|escapejs }}');
+
+            element.addEventListener('click', function(e) {
+                e.preventDefault();
+                myPicker.show();
+            });
+        });
+    });
+</script>
+
+```
+
+#### `__init__.py` and `apps.py`
+
+`init.py`:
+
+```python
+default_app_config = 'wagtail_content_import.pickers.my_picker.apps.WagtailContentImportMyPickerAppConfig'
+```
+
+`apps.py`: 
+
+```python
+from django.apps import AppConfig
+
+
+class WagtailContentImportMyPickerAppConfig(AppConfig):
+    name = 'wagtail_content_import.pickers.my_picker'
+    label = 'wagtail_content_import_my_picker'
+    verbose_name = "Wagtail Content Import - My Picker"
+```
+
+####`utils.py`
+
+Here, you'll need to create the Python class for your new picker, which will provide the names
+and context needed by the `js_init` template.
+
+```python
+from django.template.loader import render_to_string
+from django.utils.safestring import mark_safe
+
+from wagtail_content_import.pickers import Picker
+
+
+class MyPicker(Picker):
+    name = "my_picker"
+    verbose_name = "My Picker"
+
+    def __init__(self, AUTH_PARAMETERS):
+        self.AUTH_PARAMETERS = AUTH_PARAMETERS
+
+    def get_context(self):
+        return {
+            'picker': self,
+            'AUTH_PARAMETERS': self.AUTH_PARAMETERS,
+        }
+
+    js_template = 'wagtail_content_import/MY_PICKER_js_init.html'
+
+    def render_js_init(self, request):
+        return mark_safe(render_to_string(self.js_template, self.get_context(), request=request))
+
+    class Media:
+        css = {}
+        js = [
+            # ANY EXTRA JS YOU NEED HERE 
+            'wagtail_content_import/MY_PICKER.js',
+        ]
+```
+
+###`wagtail_hooks.py`
+
+Finally, here you'll need to register your picker, and add a `before create page` hook to actually
+import posted content.
+
+Eg:
+
+```python
+from django.conf import settings
+
+from wagtail.core import hooks
+
+from .utils import MyPicker
+
+from ...utils import create_page_from_import
+
+
+@hooks.register("before_create_page")
+def create_from_my_doc(request, parent_page, page_class):
+    if "my-doc" in request.POST:
+        parsed_doc = # PARSE THE DOCUMENT HERE
+        return create_page_from_import(request, parent_page, page_class, parsed_doc)
+
+
+@hooks.register('register_content_import_picker')
+def register_content_import_picker():
+    return MyPicker(
+        settings.AUTH_PARAMETERS,
+    )
+```

--- a/docs/submitting_backend.md
+++ b/docs/submitting_backend.md
@@ -7,7 +7,7 @@ to the [Wagtail Content Import repository](https://github.com/torchbox/wagtail-c
 If you're planning on submitting a new picker - apps which enable choosing and importing a file from a 
 remote source - you'll need to follow this blueprint:
 
-###Overview and File Structure
+### Overview and File Structure
 
 Inside `wagtail_content_import.pickers`, your app should have the following structure:
 
@@ -39,7 +39,7 @@ to actually take the POST-ed document data and import it, using a parser.
 The following examples will follow a picker which needs a variable `AUTH_PARAMETERS` available in the 
 JavaScript in order to import content.
 
-####`MY_PICKER.js`
+#### `MY_PICKER.js`
 
 This adds the JavaScript class for your picker, and adds it to the window. It should implement
 a method to show the picker, and upon choosing, make a POST request to the page using a hidden form
@@ -91,7 +91,7 @@ Eg:
 })();
 ```
 
-####`MY_PICKER_js_init.html`
+#### `MY_PICKER_js_init.html`
 
 This should provide a Django template which creates an instance of your JS picker class, populated with
 the relevant variables, which can be filled in by the Django side using your Python picker class. It must also add a listener to the 
@@ -135,7 +135,7 @@ class WagtailContentImportMyPickerAppConfig(AppConfig):
     verbose_name = "Wagtail Content Import - My Picker"
 ```
 
-####`utils.py`
+#### `utils.py`
 
 Here, you'll need to create the Python class for your new picker, which will provide the names
 and context needed by the `js_init` template.
@@ -173,7 +173,7 @@ class MyPicker(Picker):
         ]
 ```
 
-###`wagtail_hooks.py`
+### `wagtail_hooks.py`
 
 Finally, here you'll need to register your picker, and add a `before create page` hook to actually
 import posted content.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,16 @@
+site_name: Wagtail Content Import Documentation
+theme:
+  name: 'material'
+nav:
+    - Home: index.md
+    - Getting Started: getting_started.md
+      - Google Docs Setup: google_docs_setup.md
+      - Microsoft Setup: microsoft_setup.md
+    - Basic Usage: basic_usage.md
+    - The Content Import Flow: flow.md
+    - Customisation: customisation.md
+      - Writing Custom Converters: custom_converters.md
+      - Working With StructBlocks: structblocks.md
+      - Changing Import Fields: changing_import_fields.md
+    - Settings Reference: settings.md
+    - Submitting a New Backend: submitting_backend.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,12 +3,13 @@ theme:
   name: 'material'
 nav:
     - Home: index.md
-    - Getting Started: getting_started.md
+    - Getting Started:
+      - Basic Setup: getting_started.md
       - Google Docs Setup: google_docs_setup.md
       - Microsoft Setup: microsoft_setup.md
     - Basic Usage: basic_usage.md
     - The Content Import Flow: flow.md
-    - Customisation: customisation.md
+    - Customisation:
       - Writing Custom Converters: custom_converters.md
       - Working With StructBlocks: structblocks.md
       - Changing Import Fields: changing_import_fields.md


### PR DESCRIPTION
Adds a basic mkdocs site, extending and replacing the readme documentation with
- More recipes (for creating a new Picker, and custom converters)
- Info on Microsoft setup
- General rewording