### PR TITLE
Take title from provided alt text title option on gdocs if available,…

### DIFF
--- a/wagtail_content_import/mappers/converters.py
+++ b/wagtail_content_import/mappers/converters.py
@@ -40,7 +40,8 @@ class TextConverter(BaseConverter):
 class ImageConverter(BaseConverter):
     def __call__(self, element, user, **kwargs):
         image_name, image_content = self.fetch_image(element['value'])
-        image = self.import_as_image_model(image_name, image_content, owner=user)
+        title = element.get('title', '')
+        image = self.import_as_image_model(title, image_content, owner=user)
         return (self.block_name, image)
 
     @staticmethod

--- a/wagtail_content_import/parsers/google.py
+++ b/wagtail_content_import/parsers/google.py
@@ -70,10 +70,12 @@ class GoogleDocumentParser(DocumentParser):
         embed = self.document['inlineObjects'][embed_id]
         # Currently we only handle images
         image_props = embed['inlineObjectProperties']['embeddedObject'].get('imageProperties')
+        title = embed['inlineObjectProperties']['embeddedObject'].get('title', '')
         if image_props:
             return {
                 'type': 'image',
-                'value': image_props['contentUri']
+                'value': image_props['contentUri'],
+                'title': title
             }
 
     def process_list(self, list_items):


### PR DESCRIPTION
… and blank if not

This prevents title - and with the default Wagtail image model, alt text - being set to a filename, which is bad for accessibility as usually these are nonsensical.