### PR TITLE
Shared drive support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ with io.open('README.md', encoding='utf-8') as readme_file:
 
 setup(
     name='wagtail_content_import',
-    version="0.2.1",
+    version="0.2.2",
     description='A module for Wagtail that provides functionality for importing page content from third-party sources.',
     author='Samir Shah, Jacob Topp-Mugglestone, Karl Hobley, Matthew Westcott',
     author_email='jacobtm@torchbox.com',

--- a/wagtail_content_import/pickers/google/static/wagtail_content_import/google_picker.js
+++ b/wagtail_content_import/pickers/google/static/wagtail_content_import/google_picker.js
@@ -42,17 +42,26 @@
         }
 
         picker(oauthToken, callback) {
-            let view = new google.picker.View(google.picker.ViewId.DOCS);
-            view.setMimeTypes("application/vnd.google-apps.document");
+            let docsView = new google.picker.DocsView(google.picker.ViewId.DOCUMENTS);
+            docsView.setMimeTypes("application/vnd.google-apps.document");
+            docsView.setSelectFolderEnabled(true);
+            docsView.setIncludeFolders(true);
+
+
+            let sharedDrivesView = new google.picker.DocsView(google.picker.ViewId.DOCUMENTS);
+            sharedDrivesView.setMimeTypes("application/vnd.google-apps.document");
+            sharedDrivesView.setSelectFolderEnabled(true);
+            sharedDrivesView.setIncludeFolders(true);
+            sharedDrivesView.setEnableDrives(true);
+
 
             let picker = new google.picker.PickerBuilder()
-                .enableFeature(google.picker.Feature.NAV_HIDDEN)
                 .enableFeature(google.picker.Feature.SUPPORT_DRIVES)
                 .setAppId(this.authOptions.appId)
                 .setDeveloperKey(this.authOptions.pickerApiKey)
                 .setOAuthToken(oauthToken)
-                .addView(view)
-                .addView(new google.picker.DocsUploadView())
+                .addView(docsView)
+                .addView(sharedDrivesView)
                 .setCallback(callback)
                 .build();
 


### PR DESCRIPTION
Adds a separate view for navigating shared drives in the Google Picker, making it easier to find documents by source