### PR TITLE
Fix settings issues

### DIFF
--- a/docs/microsoft_setup.md
+++ b/docs/microsoft_setup.md
@@ -18,4 +18,4 @@ Wagtail OneDrive/SharePoint integration relies on Microsoft APIs, which you will
 
 4. Navigate to `Authentication`. Under `Implicit grant`, add `Access tokens` and `ID tokens`, and save.
 
-5. Finally, navigate to `Overview`, and copy the `Application (client) ID` into the `MICROSOFT_CLIENT_ID` setting.
+5. Finally, navigate to `Overview`, and copy the `Application (client) ID` into the `WAGTAIL_CONTENT_IMPORT_MICROSOFT_CLIENT_ID` setting.

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -1,0 +1,7 @@
+# Release Notes
+
+## Version 0.3.0 (26/02/2020)
+
+- Fix: settings for pickers will no longer cause errors in the edit view when unset or set to blank strings - instead, pickers will hide themselves.
+- Update: settings for pickers are now prefixed with `WAGTAIL_CONTENT_IMPORT_`, so the names are now `WAGTAIL_CONTENT_IMPORT_GOOGLE_PICKER_API_KEY`,
+  `WAGTAIL_CONTENT_IMPORT_GOOGLE_OAUTH_CLIENT_CONFIG` and `WAGTAIL_CONTENT_IMPORT_MICROSOFT_CLIENT_ID`. Make sure to change these when updating!

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -22,3 +22,4 @@ nav:
       - Changing Import Fields: changing_import_fields.md
     - Settings Reference: settings.md
     - Submitting a New Backend: submitting_backend.md
+    - Release Notes: release_notes.md

--- a/wagtail_content_import/pickers/google/wagtail_hooks.py
+++ b/wagtail_content_import/pickers/google/wagtail_hooks.py
@@ -17,7 +17,10 @@ def create_from_google_doc(request, parent_page, page_class):
 
 @hooks.register('register_content_import_picker')
 def register_content_import_picker():
-    return GooglePicker(
-        settings.GOOGLE_OAUTH_CLIENT_CONFIG,
-        settings.GOOGLE_PICKER_API_KEY,
-    )
+    client_config = getattr(settings, "WAGTAIL_CONTENT_IMPORT_GOOGLE_OAUTH_CLIENT_CONFIG", "")
+    api_key = getattr(settings, "WAGTAIL_CONTENT_IMPORT_GOOGLE_PICKER_API_KEY", "")
+    if client_config and api_key:
+        return GooglePicker(
+            client_config,
+            api_key,
+        )

--- a/wagtail_content_import/pickers/microsoft/wagtail_hooks.py
+++ b/wagtail_content_import/pickers/microsoft/wagtail_hooks.py
@@ -12,7 +12,9 @@ from ...utils import create_page_from_import
 
 @hooks.register('register_content_import_picker')
 def register_content_import_picker():
-    return MicrosoftPicker(settings.MICROSOFT_CLIENT_ID)
+    client_id = getattr(settings, "WAGTAIL_CONTENT_IMPORT_MICROSOFT_CLIENT_ID", "")
+    if client_id:
+        return MicrosoftPicker(client_id)
 
 
 @hooks.register("before_create_page")

--- a/wagtail_content_import/templatetags/wagtailcontentimport_tags.py
+++ b/wagtail_content_import/templatetags/wagtailcontentimport_tags.py
@@ -9,7 +9,7 @@ register = template.Library()
 
 @register.simple_tag(takes_context=True)
 def wagtailcontentimport_pickerjs(context):
-    pickers = [fn() for fn in hooks.get_hooks('register_content_import_picker')]
+    pickers = [fn() for fn in hooks.get_hooks('register_content_import_picker') if fn()]
 
     js_snippets = []
 


### PR DESCRIPTION
Update picker settings variable names to avoid conflicts (new prefix `WAGTAIL_CONTENT_IMPORT_'). 

Check for blank and unset settings variables before showing picker to avoid errors in edit view in environments where these are not used