### PR TITLE
Gdocs parser additional features

### DIFF
--- a/docs/converter_reference.md
+++ b/docs/converter_reference.md
@@ -17,6 +17,6 @@ Passes the element's `value` field directly through as the block content. Note t
 Imports an image found at the url given by the element's `value`, setting the title to the element's `title` if given, and the owner to the `user` kwarg if
 provided on calling, and returns the image as the block content.
 
-## `TableConverter(block_name)
+## `TableConverter(block_name)`
 
 Produces a text table from the intermediate table representation, compatible with `wagtail.contrib.table_block.blocks.TableBlock`.

--- a/docs/converter_reference.md
+++ b/docs/converter_reference.md
@@ -1,0 +1,22 @@
+# Converters
+
+Converters are callable classes, which when called, take elements of the intermediate `{'type': type, 'value': value}` format (and keyword arguments) and
+return streamfield-compatible tuples of the `(block_name, block_content)` form. All converters inherit from `wagtail_content_import.mappers.converters.BaseConverter`, and take a `block_name` on init.
+
+## `RichTextConverter(block_name, features=None)`
+
+Produces Draftail-compatible html suitable for a `RichTextBlock`, using either the features listed in `features` or the basic rich text features
+registered in the Wagtail feature registry (see [the Wagtail documentation](https://docs.wagtail.io/en/v2.8/advanced_topics/customisation/page_editing_interface.html)).
+
+## `TextConverter(block_name)`
+
+Passes the element's `value` field directly through as the block content. Note that this must be escaped, as no whitelisting takes place.
+
+## `ImageConverter(block_name)`
+
+Imports an image found at the url given by the element's `value`, setting the title to the element's `title` if given, and the owner to the `user` kwarg if
+provided on calling, and returns the image as the block content.
+
+## `TableConverter(block_name)
+
+Produces a text table from the intermediate table representation, compatible with `wagtail.contrib.table_block.blocks.TableBlock`.

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -1,5 +1,13 @@
 # Release Notes
 
+## Version 0.3.2 (03/03/2020)
+
+- Update: `GoogleDocumentsParser` parser now parses underline, superscript, subscript, and strikethrough styles. (Note that using nonstandard
+  rich text features requires adding them to both the `RichTextConverter` class and the `RichTextField` or block)
+- Update: `RichTextConverter` now uses the Draftail `ContentstateConverter` to validate imported content, so correctly accepts features available in 
+  Draftail but not Hallo.js
+- Update: `GoogleDocumentsParser` now converts heading styles in Google Docs more straightforwardly to html tags. For example, `HEADING_2` maps to `h2` tags.
+
 ## Version 0.3.1 (27/02/2020)
 
 - Update: settings for pickers are now prefixed with `WAGTAILCONTENTIMPORT_` for consistency, so the names are 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -23,3 +23,5 @@ nav:
     - Settings Reference: settings.md
     - Submitting a New Backend: submitting_backend.md
     - Release Notes: release_notes.md
+    - Reference:
+      - Converters: converter_reference.md

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ with io.open('README.md', encoding='utf-8') as readme_file:
 
 setup(
     name='wagtail_content_import',
-    version="0.3.1",
+    version="0.3.2",
     description='A module for Wagtail that provides functionality for importing page content from third-party sources.',
     author='Samir Shah, Jacob Topp-Mugglestone, Karl Hobley, Matthew Westcott',
     author_email='jacobtm@torchbox.com',

--- a/wagtail_content_import/mappers/converters.py
+++ b/wagtail_content_import/mappers/converters.py
@@ -1,9 +1,9 @@
-from wagtail.core.rich_text import RichText
+from wagtail.core.rich_text import features as feature_registry, RichText
 
 from django.utils.functional import cached_property
 from django.core.files.base import ContentFile
 from wagtail.images import get_image_model
-from wagtail.admin.rich_text.converters.editor_html import EditorHTMLConverter
+from wagtail.admin.rich_text.converters.contentstate import ContentstateConverter
 
 import requests
 
@@ -24,11 +24,15 @@ class RichTextConverter(BaseConverter):
         super().__init__(block_name)
 
     @cached_property
-    def editor_html_converter(self):
-        return EditorHTMLConverter(self.features)
+    def contentstate_converter(self):
+        if self.features is None:
+            features = feature_registry.get_default_features()
+        else:
+            features = self.features
+        return ContentstateConverter(features=features)
 
     def __call__(self, element, **kwargs):
-        cleaned_html = self.editor_html_converter.to_database_format(element['value'])
+        cleaned_html = self.contentstate_converter.to_database_format(self.contentstate_converter.from_database_format(element['value']))
         return (self.block_name, RichText(cleaned_html))
 
 

--- a/wagtail_content_import/parsers/google.py
+++ b/wagtail_content_import/parsers/google.py
@@ -212,13 +212,15 @@ class GoogleDocumentParser(DocumentParser):
                 close_current_list()
 
                 if paragraph['paragraphStyle']['namedStyleType'] == 'HEADING_2':
-                    outer_tag = 'h3'
+                    outer_tag = 'h2'
                 elif paragraph['paragraphStyle']['namedStyleType'] == 'HEADING_3':
+                    outer_tag = 'h3'
+                elif paragraph['paragraphStyle']['namedStyleType'] == 'HEADING_4':
                     outer_tag = 'h4'
-                elif paragraph['paragraphStyle']['namedStyleType'] == 'HEADING_4':
+                elif paragraph['paragraphStyle']['namedStyleType'] == 'HEADING_5':
                     outer_tag = 'h5'
-                elif paragraph['paragraphStyle']['namedStyleType'] == 'HEADING_4':
-                    outer_tag = 'h5'
+                elif paragraph['paragraphStyle']['namedStyleType'] == 'HEADING_6':
+                    outer_tag = 'h6'
                 else:
                     outer_tag = 'p'
 

--- a/wagtail_content_import/parsers/google.py
+++ b/wagtail_content_import/parsers/google.py
@@ -44,6 +44,18 @@ class GoogleDocumentParser(DocumentParser):
             if style.get('italic'):
                 prefixes.append('<i>')
                 suffixes.append('</i>')
+            if style.get('underline'):
+                prefixes.append('<u>')
+                suffixes.append('</u>')
+            if style.get('baselineOffset') == 'SUPERSCRIPT':
+                prefixes.append('<sup>')
+                suffixes.append('</sup>')
+            elif style.get('baselineOffset') == 'SUBSCRIPT':
+                prefixes.append('<sub>')
+                suffixes.append('</sub>')
+            if style.get('strikethrough'):
+                prefixes.append('<s>')
+                suffixes.append('</s>')                
             if style.get('link'):
                 url = style['link'].get('url')
                 # Links without a 'url' field are local bookmark/heading references;


### PR DESCRIPTION
Changes RichTextConverter to convert to and from the Draftail representation, rather than using the old hallo.js whitelister. 

Add strikethrough, superscript, subscript, and underline to GDocs parser.

Add a quick converter reference section to docs.

Make headings styles convert to html headings more equivalently - GDocs HEADING_2 to h2, for example