### PR TITLE
Add warning note about requirement for cookie settings when using Drive import

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,7 @@ Currently supports:
 * Wagtail 2.2
 
 For the full documentation, see: https://torchbox.github.io/wagtail-content-import/
+
+### Note for Google Import
+
+If using Google Docs import, for users to authenticate with Google they must either allow third party cookies or add `accounts.google.com` to their allowed domains ([Settings/Privacy and Security/Cookies and other site data in Chrome](chrome://settings/cookies) or [Preferences/Privacy & Security in Firefox](about:preferences#privacy)).

--- a/docs/google_docs_setup.md
+++ b/docs/google_docs_setup.md
@@ -31,3 +31,7 @@ Wagtail Google Docs integration relies on Google APIs, which you will first need
     secret.
 
  10. Copy the text from this file, and use it to set `WAGTAILCONTENTIMPORT_GOOGLE_OAUTH_CLIENT_CONFIG`.
+
+## Note
+
+For users to authenticate with Google and import documents from their Drives, they must either allow third party cookies or add `accounts.google.com` to their allowed domains ([Settings/Privacy and Security/Cookies and other site data in Chrome](chrome://settings/cookies) or [Preferences/Privacy & Security in Firefox](about:preferences#privacy)).


### PR DESCRIPTION
Users disallowing third party cookies (now default on incognito mode) breaks Google client side auth, as warned https://developers.google.com/identity/sign-in/web/troubleshooting#third-party_cookies_and_data_blocked. This PR adds a warning to the README and the Google Setup docs about the fix needed.