### PR TITLE
Adds check on element in paragraph["elements"]

### DIFF
--- a/wagtail_content_import/parsers/google.py
+++ b/wagtail_content_import/parsers/google.py
@@ -34,6 +34,10 @@ class GoogleDocumentParser(DocumentParser):
                 embeds.append(element["inlineObjectElement"]["inlineObjectId"])
                 continue
 
+            if not element:
+                # paragraph["elements"] may contain `NoneType` values, if it does, just skip it.
+                continue
+
             text_run = element.get("textRun")
             content = text_run.get("content", "").strip("\n")
             if not content or not text_run:


### PR DESCRIPTION
Adds a check to ensure the element exists before trying to do a `.get` on it. 

We were getting an error in our reporting that showed `'NoneType' object has no attribute 'get'` specifically on the element. So this checks that the element is not falsey before trying to continue. 