### PR TITLE
Initialise gapi client, store oauth token in localStorage

### DIFF
--- a/wagtail_content_import/pickers/google/static/wagtail_content_import/google_picker.js
+++ b/wagtail_content_import/pickers/google/static/wagtail_content_import/google_picker.js
@@ -8,7 +8,7 @@
             this.csrfToken = csrfToken;
 
             this.clientInitialised = false;
-            this.accessToken = null;
+            this.accessToken = localStorage.getItem("contentImportGoogleAccessToken");
         }
 
         picker() {
@@ -29,40 +29,45 @@
                 .setOAuthToken(this.accessToken)
                 .addView(docsView)
                 .addView(sharedDrivesView)
-                .setCallback(this.pickerCallback)
+                .setCallback(this.getPickerCallBack())
                 .build();
 
             picker.setVisible(true);
         }
 
-        pickerCallback(data) {
-            if (data.action == google.picker.Action.PICKED) {
-                gapi.client.docs.documents.get({
-                    documentId: data.docs[0].id
-                }).then((response) => {
-                    // POST the JSON content of the document to the create page view
-                    // Use a hidden form so the browser reloads with the result of this request
-                    let form = document.createElement('form');
-                    form.action = this.importPageUrl;
-                    form.method = 'POST';
-                    form.style.visibility = 'hidden';
-                    document.body.appendChild(form);
+        getPickerCallBack() {
+            // The callback will be executed with `this' not bound to an instance of this class,
+            // so bind the required members in a closure
+            const { csrfToken, importPageUrl } = this;
+            return (data) => {
+                if (data.action == google.picker.Action.PICKED) {
+                    gapi.client.docs.documents.get({
+                        documentId: data.docs[0].id
+                    }).then((response) => {
+                        // POST the JSON content of the document to the create page view
+                        // Use a hidden form so the browser reloads with the result of this request
+                        let form = document.createElement('form');
+                        form.action = importPageUrl;
+                        form.method = 'POST';
+                        form.style.visibility = 'hidden';
+                        document.body.appendChild(form);
 
-                    let csrfTokenField = document.createElement('input');
-                    csrfTokenField.type = 'hidden';
-                    csrfTokenField.name = 'csrfmiddlewaretoken';
-                    csrfTokenField.value = this.csrfToken;
-                    form.appendChild(csrfTokenField);
+                        let csrfTokenField = document.createElement('input');
+                        csrfTokenField.type = 'hidden';
+                        csrfTokenField.name = 'csrfmiddlewaretoken';
+                        csrfTokenField.value = csrfToken;
+                        form.appendChild(csrfTokenField);
 
-                    let googleDocField = document.createElement('input');
-                    googleDocField.type = 'hidden';
-                    googleDocField.name = 'google-doc';
-                    googleDocField.value = response.body;
-                    form.appendChild(googleDocField);
+                        let googleDocField = document.createElement('input');
+                        googleDocField.type = 'hidden';
+                        googleDocField.name = 'google-doc';
+                        googleDocField.value = response.body;
+                        form.appendChild(googleDocField);
 
-                    form.submit();
-                });
-            }
+                        form.submit();
+                    });
+                }
+            };
         }
 
         show() {
@@ -72,12 +77,15 @@
             }
 
             if (!this.clientInitialised) {
-                gapi.load('picker', () => {
+                gapi.load('client', async () => {
+                    await gapi.client.init({
+                        apiKey: this.authOptions.pickerApiKey,
+                        discoveryDocs: ['https://docs.googleapis.com/$discovery/rest?version=v1'],
+                    });
                     this.clientInitialised = true;
-                    this.show()
+                    gapi.load('picker', () => { this.show() });
                 });
-            }
-            else {
+            } else {
                 let tokenClient = google.accounts.oauth2.initTokenClient({
                     client_id: this.authOptions.clientId,
                     scope: GOOGLE_API_SCOPE,
@@ -85,6 +93,7 @@
                         if (response.error !== undefined) {
                             throw (response);
                         }
+                        localStorage.setItem("contentImportGoogleAccessToken", response.access_token);
                         this.accessToken = response.access_token;
                         this.picker();
                     }


### PR DESCRIPTION
I picked this up from @zerolab 's PR [here](https://github.com/torchbox/wagtail-content-import/pull/56), so this PR is targeting that branch.

The goal is to migrate to the new Google Identity Service, which Dan started the work on. The further steps taken in this PR are:

- Makes sure the gapi JS client is initialised so we can call the docs endpoint on it.
- Stores the oauth token in `localStorage` so users can benefit from a persistent session.
- Refactors the `pickerCallback` to get around `this` not being the `GooglePicker` in the scope where the callback is executed, causing the generated form to not have the page URL and CSRF token.

I'm able to authenticate using the code in this PR.