### PR TITLE
fix: update function signature for wagtail 6.4

### DIFF
--- a/wagtail_content_import/utils.py
+++ b/wagtail_content_import/utils.py
@@ -34,8 +34,8 @@ def update_page_from_import(request, page, parsed_doc):
     page.update_from_import(parsed_doc, request.user)
 
     class CustomEditView(EditView):
-        def post(self, request):
+        def post(self, request, *args, **kwargs):
             self.page = page
-            return self.get(request)
+            return self.get(request, *args, **kwargs)
 
     return CustomEditView.as_view()(request, page.pk)


### PR DESCRIPTION
Fixes #70.

Just to note explicitly: this change fixes a compatibility issue with Wagtail 6.4, but it should be backwards compatible.