### PR TITLE
Wagtail 7.4 maintenance

### DIFF
--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -16,7 +16,7 @@ jobs:
     - uses: actions/checkout@v5
 
     # Keep in sync with .pre-commit-config.yaml
-    - run: python -Im pip install --user ruff==0.14.4
+    - run: python -Im pip install --user ruff==0.15.12
 
     - name: Run ruff
       working-directory: ./src

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
       matrix:
         python-version: ["3.12", "3.13"]
         django: [ "5.2" ]
-        wagtail: [ "7.0" ]
+        wagtail: [ "7.4" ]
         database: [ "sqlite" ]
     steps:
       - uses: actions/checkout@v5

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
       - id: trailing-whitespace
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # keep in sync with .github/workflows/ruff.yml
-    rev: 'v0.14.4'
+    rev: 'v0.15.12'
     hooks:
       - id: ruff-check
         args: [ --fix ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.14.0] - 2026-05-05
+## [Unreleased]
 
 - Add support for Wagtail 7.3 and 7.4 LTS
 - Drop support for Wagtail 6.3 (EOL), 7.1 (EOL), and 7.2 (EOL)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - Add support for Wagtail 7.3 and 7.4 LTS
-- Drop support for Wagtail 6.3 (EOL), 7.1 (EOL), and 7.2 (EOL)
-- Drop support for Python 3.9 (EOL as of October 2025)
-- Drop support for Django 5.1 (EOL)
+- Drop support for Wagtail < 7.3, Python < 3.10 and Django < 5.2
 
 ## [0.13.2] - 2026-02-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.14.0] - 2026-05-05
+
+- Add support for Wagtail 7.3 and 7.4 LTS
+- Drop support for Wagtail 6.3 (EOL), 7.1 (EOL), and 7.2 (EOL)
+- Drop support for Python 3.9 (EOL as of October 2025)
+- Drop support for Django 5.1 (EOL)
+
 ## [0.13.2] - 2026-02-19
 
 - Compatibility fix for Django 6.0

--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ Currently, it supports:
     - Headings
 
 ### Requirements:
-* Python >= 3.9
+* Python >= 3.10
 * Django >= 4.2
-* Wagtail >= 6.3
+* Wagtail >= 7.0
 
 For the full documentation, see: https://torchbox.github.io/wagtail-content-import/
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -1,6 +1,7 @@
 ## Requirements:
-* Django 4.2 or 5.0
-* Wagtail 5.2 or 6.0
+* Python >= 3.10
+* Django >= 4.2
+* Wagtail >= 7.0
 
 ### To set up:
  1. Run `python3 pip install wagtail-content-import`.

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -1,6 +1,6 @@
 # Release Notes
 
-## Version 0.14.0 (2026-05-05)
+## Unreleased
 
 - Add support for Wagtail 7.3 and 7.4 LTS
 - Drop support for Wagtail 6.3 (EOL), 7.1 (EOL), and 7.2 (EOL)

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -3,9 +3,7 @@
 ## Unreleased
 
 - Add support for Wagtail 7.3 and 7.4 LTS
-- Drop support for Wagtail 6.3 (EOL), 7.1 (EOL), and 7.2 (EOL)
-- Drop support for Python 3.9 (EOL as of October 2025)
-- Drop support for Django 5.1 (EOL)
+- Drop support for Wagtail < 7.3, Python < 3.10 and Django < 5.2
 
 ## Version 0.13.2 (2026-02-19)
 

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -1,5 +1,20 @@
 # Release Notes
 
+## Version 0.14.0 (2026-05-05)
+
+- Add support for Wagtail 7.3 and 7.4 LTS
+- Drop support for Wagtail 6.3 (EOL), 7.1 (EOL), and 7.2 (EOL)
+- Drop support for Python 3.9 (EOL as of October 2025)
+- Drop support for Django 5.1 (EOL)
+
+## Version 0.13.2 (2026-02-19)
+
+- Compatibility fix for Django 6.0
+
+## Version 0.13.1 (2025-12-10)
+
+- Maintenance update for Wagtail 7.0, 7.1 & 7.2 compatibility
+
 ## Version 0.12.2 (2025-03-21)
 
 - Fix method signature for Wagtail 6.4 (@andylolz)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,18 +30,16 @@ classifiers = [
     "Programming Language :: Python :: 3.14",
     "Framework :: Django",
     "Framework :: Django :: 4.2",
-    "Framework :: Django :: 5.1",
     "Framework :: Django :: 5.2",
     "Framework :: Django :: 6.0",
     "Framework :: Wagtail",
-    "Framework :: Wagtail :: 6",
     "Framework :: Wagtail :: 7",
 ]
 
 dynamic = ["version"]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = [
-    "Wagtail>=6.3",
+    "Wagtail>=7.0",
     "python-docx>=1.2.0"
 ]
 
@@ -50,7 +48,7 @@ testing = [
     # Required for running the tests
     "mock>=5.2.0",
     # For coverage and PEP8 linting
-    "coverage>=7.11.3",
+    "coverage>=7.13",
     "tox>=4.32.0",
     "dj-database-url>=3,<4"
 ]

--- a/src/wagtail_content_import/__init__.py
+++ b/src/wagtail_content_import/__init__.py
@@ -1,3 +1,3 @@
-__version__ = "0.13.2"
+__version__ = "0.14.0"
 
 WAGTAIL_CONTENT_IMPORT_REQUEST_TIMEOUT = 25

--- a/src/wagtail_content_import/__init__.py
+++ b/src/wagtail_content_import/__init__.py
@@ -1,3 +1,3 @@
-__version__ = "0.14.0"
+__version__ = "0.13.2"
 
 WAGTAIL_CONTENT_IMPORT_REQUEST_TIMEOUT = 25

--- a/src/wagtail_content_import/mappers/converters.py
+++ b/src/wagtail_content_import/mappers/converters.py
@@ -174,7 +174,9 @@ class ImageConverter(BaseConverter):
             # some other hashing scheme
             if potential_duplicate.file.size == image.file.size and all(
                 a == b
-                for a, b in zip(potential_duplicate.file.chunks(), image.file.chunks())
+                for a, b in zip(
+                    potential_duplicate.file.chunks(), image.file.chunks(), strict=False
+                )
             ):
                 # We've found an existing image in the library
                 # so let's not save our new image, and return this one instead

--- a/src/wagtail_content_import/mappers/converters.py
+++ b/src/wagtail_content_import/mappers/converters.py
@@ -145,13 +145,7 @@ class ImageConverter(BaseConverter):
 
         # Set image file hash
         image.file.seek(0)
-        try:
-            image._set_file_hash(image.file.read())
-        except TypeError:
-            # This argumentless version was introduced in Wagtail 4.2.2
-            # https://github.com/wagtail/wagtail/commit/3c0c64642b9e5b8d28b111263c7f4bddad6c3880
-            # we can probably drop this try/except pattern when it's in a new major version
-            image._set_file_hash()
+        image._set_file_hash()
         image.file.seek(0)
 
         # Before we save the image, let's check if there are any choosable images with the same hash

--- a/src/wagtail_content_import/templates/wagtail_content_import/action_menu_wrapper.html
+++ b/src/wagtail_content_import/templates/wagtail_content_import/action_menu_wrapper.html
@@ -1,5 +1,0 @@
-<li class="actions actions--primary">
-    <div class="dropdown dropup dropdown-button match-width">
-        {% include "wagtailadmin/pages/action_menu/menu.html" %}
-    </div>
-</li>

--- a/src/wagtail_content_import/templatetags/wagtailcontentimport_tags.py
+++ b/src/wagtail_content_import/templatetags/wagtailcontentimport_tags.py
@@ -3,7 +3,6 @@ import re
 from django import template
 from django.urls import reverse
 from django.utils.html import format_html_join
-from wagtail import VERSION as WAGTAIL_VERSION
 from wagtail import hooks
 from wagtail.admin.action_menu import ActionMenuItem
 
@@ -70,10 +69,7 @@ def get_picker_buttons_context(context, view):
     return context
 
 
-if WAGTAIL_VERSION >= (6, 0):
-    action_menu_template = "wagtailadmin/pages/action_menu/menu.html"
-else:
-    action_menu_template = "wagtail_content_import/action_menu_wrapper.html"
+action_menu_template = "wagtailadmin/pages/action_menu/menu.html"
 
 
 @register.inclusion_tag(action_menu_template, takes_context=True)

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ min_version = 4.30.2
 envlist =
     python{3.10,3.11,3.12}-django4.2-wagtail7.0-{sqlite,postgres}
     python{3.10,3.11,3.12,3.13}-django5.2-wagtail{7.0,7.3,7.4}-{sqlite,postgres}
-    python{3.12,3.13,3.14}-django6.0-wagtail{7.3,7.4,main}-{sqlite,postgres}
+    python{3.12,3.13,3.14}-django6.0-wagtail{7.4,main}-{sqlite,postgres}
 
 [gh-actions]
 python =

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,8 @@
 min_version = 4.30.2
 
 envlist =
-    python{3.10,3.11}-django4.2-wagtail{7.0,7.3,7.4}-{sqlite,postgres}
-    python{3.10,3.11,3.12,3.13}-django5.2-wagtail{7.0,7.4}-{sqlite,postgres}
+    python{3.10,3.11,3.12}-django4.2-wagtail7.0-{sqlite,postgres}
+    python{3.10,3.11,3.12,3.13}-django5.2-wagtail{7.0,7.3,7.4}-{sqlite,postgres}
     python{3.12,3.13,3.14}-django6.0-wagtail{7.3,7.4,main}-{sqlite,postgres}
 
 [gh-actions]

--- a/tox.ini
+++ b/tox.ini
@@ -2,9 +2,9 @@
 min_version = 4.30.2
 
 envlist =
-    python{3.10,3.11}-django4.2-wagtail{6.3,7.0,7.1,7.2}-{sqlite,postgres}
-    python{3.12,3.13}-django{5.1,5.2}-wagtail{6.3,7.0}-{sqlite,postgres}
-    python{3.14}-django{5.2}-wagtail{7.2,main}-{sqlite,postgres}
+    python{3.10,3.11}-django4.2-wagtail{7.0,7.3,7.4}-{sqlite,postgres}
+    python{3.10,3.11,3.12,3.13}-django5.2-wagtail{7.0,7.4}-{sqlite,postgres}
+    python{3.12,3.13,3.14}-django6.0-wagtail{7.3,7.4,main}-{sqlite,postgres}
 
 [gh-actions]
 python =
@@ -34,16 +34,15 @@ setenv =
 extras = testing
 
 deps =
-    coverage>=7.7
+    coverage>=7.13
 
     django4.2: Django>=4.2,<5.0
-    django5.1: Django>=5.1,<5.2
     django5.2: Django>=5.2,<5.3
+    django6.0: Django>=6.0,<6.1
 
-    wagtail6.3: wagtail>=6.3,<6.4
     wagtail7.0: wagtail>=7.0,<7.1
-    wagtail7.1: wagtail>=7.1,<7.2
-    wagtail7.2: wagtail>=7.2,<7.3
+    wagtail7.3: wagtail>=7.3,<7.4
+    wagtail7.4: wagtail>=7.4,<7.5
     wagtailmain: git+https://github.com/wagtail/wagtail.git
 
     postgres: psycopg
@@ -55,7 +54,7 @@ commands =
 base_python = python3.13
 package = skip
 deps =
-    coverage>=7.7,<8.0
+    coverage>=7.13,<8.0
 commands_pre =
 commands =
     python -Im coverage combine


### PR DESCRIPTION
## Summary
- Add support for Wagtail 7.3 and 7.4 LTS; drop EOL Wagtail 6.3, 7.1, 7.2
- Drop Python 3.9 (EOL Oct 2025) and Django 5.1 (EOL); keep Python 3.10–3.14 and Django 4.2/5.2/6.0
- Update tox envlist, CI workflows, classifiers, README, docs, and changelog to match the new support matrix

## Code removals

With the lower bound raised to Wagtail 7.0, three stale compatibility constructs were dropped:

### 1. `mappers/converters.py` — `_set_file_hash` shim
Removed a `try/except TypeError` that fell back to the pre-Wagtail-4.2.2 signature of `Image._set_file_hash(data)`. The argumentless form has been the only valid call shape since 4.2.2 ([wagtail/wagtail@3c0c6464](https://github.com/wagtail/wagtail/commit/3c0c64642b9e5b8d28b111263c7f4bddad6c3880)), so the `except` branch is unreachable under the new floor.

### 2. `templatetags/wagtailcontentimport_tags.py` — Wagtail 6.0 version guard
Removed `if WAGTAIL_VERSION >= (6, 0): ... else: ...` and the `from wagtail import VERSION as WAGTAIL_VERSION` import. The `else` branch only fired for Wagtail < 6.0, which is far below the new lower bound. The `True` branch (`wagtailadmin/pages/action_menu/menu.html`) is now used unconditionally.

### 3. `templates/.../action_menu_wrapper.html` — deleted
This wrapper template was the fallback target of the guard above. With the `else` branch gone it has no references; modern Wagtail's `action_menu/menu.html` already includes the surrounding `<li class="actions actions--primary">` markup, so the wrapper was redundant.

No behavior change on supported Wagtail versions — each inlined branch is what those versions were already executing.

## Test plan
- [ ] CI passes across the full tox matrix (sqlite + postgres)
- [ ] `tox -e python3.13-django5.2-wagtail7.4-sqlite` runs locally
- [ ] `tox -e python3.14-django6.0-wagtail7.4-sqlite` runs locally
- [ ] Smoke-test Google Docs / OneDrive import flows in a Wagtail 7.4 admin

🤖 Generated with [Claude Code](https://claude.com/claude-code)